### PR TITLE
build(deps): override brace-expansion to ^5.0.9 to fix DoS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2908,9 +2908,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "overrides": {
     "glob": "^13.0.6",
-    "test-exclude": "^7.0.1"
+    "test-exclude": "^7.0.1",
+    "brace-expansion": "^5.0.9"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
Resolves GHSA-rgw5-rvv9-x895 (high): brace-expansion 4.0.0-5.0.8 is vulnerable to DoS via unbounded intermediate arrays, bypassing the CVE-2026-14257 mitigation. minimatch requests ^5.0.5 but npm kept resolving 5.0.8, so an explicit override pins the patched 5.0.9. npm audit now reports 0 vulnerabilities.

## PR Checklist

<!-- Please check if your PR fulfills the following requirements: -->

- [ ] Unit Tests have been added for new changes
- [ ] API tests have been updated if applicable
- [ ] All commented code has been removed
- [ ] If you've added a dependency, you've ensured license is compatible with Apache 2.0 and clearly outlined the added dependency.

## What are you changing?

<!-- Please provide a short description of the updates that are in the PR -->

## Anything the reviewer should know when reviewing this PR?

### If the there are associated PRs in other repositories, please link them here (i.e. device-management-toolkit/repo#365 )
